### PR TITLE
Create LocationAutocomplete Component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["env", "react", "es2015"]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "experimentalObjectRestSpread": true,
+            "jsx": true
+        },
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# location-field
+# Location Autocomplete
+LocationAutocomplete is a tested React component that introduces an input field with autocomplete functionality.  It leverages the Google Places API to provide a typeahead effect with address predictions, based on your established criteria.
+
+### Features:
+- configurable to:
+  - [x] bias suggestions by "target area" or by current location
+  - [x] provide suggestions by location type
+- allows multiple instances to be used on single page, without importing autocomplete library multiple times
+
+### Usage:
+Install the package by running `npm install location_field`.
+
+Simply use the component and set the styles to fit your needs:
+```jsx
+<LocationAutocomplete
+  onChange={}
+  handleDropdownSelect={}
+/>
+```
+
+__Required props:__
+- `onChange` (function)
+- `handleDropdownSelect` (function)
+
+__Required for autocomplete functionality:__
+`googleAPIKey` OR `googlePlacesLibraryURL`
+
+__Other permitted props:__
+- `name`
+- `id`
+- `placeholder`
+- `classNames`
+- `style`
+- `value`
+- `targetArea`
+- `locationType`
+- `googleAPIKey`
+- `googlePlacesLibraryURL`
+
+To bias address predictions to a specific area, set `targetArea` to a city, state:
+```jsx
+<LocationAutocomplete
+  onChange={}
+  handleDropdownSelect={}
+  targetArea="New York, NY"
+/>
+```
+If `targetArea` is not set, the component will bias results by `currentLocation`.
+
+To return a specific address type, set `locationType` to a supported location type.  For a list of all supported types, visit [supported types](https://developers.google.com/places/supported_types)
+
+### Development:
+__Available Commands:__
+- `npm run test`
+- `npm run serve`
+- `npm run lint`
+
+__Installing dependencies:__
+After cloning the repo, `cd` into directory and run `npm install`.
+
+__Running the server:__
+1. Create an `index.html` file to mount your component:
+```html
+
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <div id="container" />
+    <script type="text/javascript" src="bundle.js" charset="utf-8"></script>
+  </body>
+</html>
+```
+
+2. For the purpose of testing locally, you can use `location-autocomplete.jsx` to mount the component.  At the top of `location-autocomplete.jsx`, import React DOM, which will allow us to mount the component:
+```jsx
+import ReactDOM from 'react-dom;'
+```
+
+Using `ReactDOM`, you can render the component, or multiple instances of the component.
+
+### Contribute:
+1. Follow the steps under Development.
+2. Create an issue if one doesn't exist already.
+3. In your commit message, include `Reference` as a footer to include the issue number:
+
+```
+Commit title
+
+<What does this commit introduce?>
+
+References:
+<Issue number>
+```
+4. Open a PR.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,90 @@
+// Karma configuration
+// Generated on Mon Feb 27 2017 21:53:55 GMT-0600 (CST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test-context.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+        'test-context.js': ['webpack']
+    },
+
+    webpack: {
+        module: {
+            loaders: [
+                {
+                    test: /\.js/,
+                    exclude: /node_modules/,
+                    loader: 'babel-loader'
+                },
+                {
+                    test: /\.json$/, loader: 'json'
+                }
+            ]
+        },
+        externals: {
+            'react/addons': true,
+            'react/lib/ExecutionEnvironment': true,
+            'react/lib/ReactContext': 'window'
+        },
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "location_field",
+  "version": "1.0.0",
+  "description": "React location field component, wired with Google's API for autocomplete functionality.",
+  "main": "src/javascripts/index.js",
+  "scripts": {
+    "test": "node_modules/.bin/karma start",
+    "serve": "node_modules/.bin/webpack-dev-server",
+    "lint": "./node_modules/.bin/eslint ./src/javascripts/index.js"
+  },
+  "author": "Jennifer Sardina <jenni.sardina@gmail.com>",
+  "license": "ISC",
+  "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.21.0",
+    "babel-loader": "^6.2.10",
+    "babel-polyfill": "^6.20.0",
+    "babel-preset-env": "^1.1.8",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "enzyme": "^2.7.1",
+    "eslint": "^3.13.1",
+    "eslint-plugin-react": "^6.9.0",
+    "jasmine": "^2.5.3",
+    "jasmine-core": "^2.5.2",
+    "json-loader": "^0.5.4",
+    "karma": "^1.5.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-jasmine": "^1.1.0",
+    "karma-webpack": "^2.0.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "webpack": "^1.14.0"
+  },
+  "dependencies": {
+    "react": "^15.4.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
   },
   "dependencies": {
     "react": "^15.4.2"
-  }
+  },
+  "pre-commit": [
+    "lint",
+    "test"
+  ]
 }

--- a/spec/javascripts/location-autocomplete-spec.jsx
+++ b/spec/javascripts/location-autocomplete-spec.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import LocationAutocomplete from '../../src/javascripts/location-autocomplete.jsx';
+
+describe('<LocationAutocomplete />', function() {
+  beforeEach(function() {
+    this.handleChange = () => {};
+    this.handleDropdownSelect = () => {};
+
+    this.render = function() {
+      this.wrapper = mount(
+        <LocationAutocomplete
+          value='some value'
+          onChange={this.handleChange}
+          handleDropdownSelect={this.handleDropdownSelect}
+          googleAPIKey="someKey"
+        />
+      );
+
+      this.inputField = this.wrapper.find('input');
+    };
+  });
+
+  afterEach(function() {
+    window.google = undefined;
+    const library = document.getElementById('location-autocomplete-library');
+    if (library) { library.remove(); }
+  });
+
+  it('renders the value', function() {
+    this.render();
+    expect(this.inputField.props().value).toEqual('some value');
+  });
+
+  describe('when autocomplete library is not available', function() {
+    it('does not break the input field', function() {
+      spyOn(this, 'handleChange');
+      this.render();
+      this.wrapper.find('input').simulate('change');
+
+      expect(this.handleChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('when autocomplete library is already available', function() {
+    beforeEach(function() {
+      window.google = {
+        maps: {
+          places: {
+            Autocomplete: function() {
+              return { addListener: function() { } };
+            }
+          }
+        }
+      };
+    });
+
+    it('does not import the library again', function() {
+      this.render();
+
+      expect(document.getElementById('location-autocomplete-library')).toEqual(null);
+    });
+
+    it('binds the handleDropdownSelect handler', function() {
+      const autocomplete = spyOn(google.maps.places, 'Autocomplete').and.returnValue({
+        addListener: function() { }
+      });
+
+      spyOn(autocomplete(), 'addListener');
+      this.render();
+
+      expect(autocomplete).toHaveBeenCalledWith(
+        this.wrapper.find('input').node, { types: ['geocode'] }
+      );
+      expect(autocomplete().addListener).toHaveBeenCalledWith(
+        'place_changed',
+        this.handleDropdownSelect
+      );
+    });
+
+    describe('when locationType is set', function() {
+      it('biases autocomplete to specified locationType', function() {
+        const autocomplete = spyOn(google.maps.places, 'Autocomplete').and.returnValue({
+          addListener: function() { }
+        });
+        const wrapper = mount(
+          <LocationAutocomplete
+            locationType='(regions)'
+            onChange={this.handleChange}
+            handleDropdownSelect={this.handleDropdownSelect}
+            googleAPIKey="someKey"
+          />
+        );
+
+        expect(autocomplete).toHaveBeenCalledWith(
+          wrapper.find('input').node, { types: ['(regions)'] }
+        );
+      });
+    });
+  });
+
+  describe('when rendering multiple instances of LocationAutocomplete', function() {
+    it('loads the autocomplete library only once', function() {
+      this.render();
+      this.render();
+
+      expect(document.querySelectorAll('#location-autocomplete-library').length).toEqual(1);
+    });
+  });
+});

--- a/spec/javascripts/support/jasmine.json
+++ b/spec/javascripts/support/jasmine.json
@@ -1,0 +1,7 @@
+{
+  "spec_dir": "spec/javascripts",
+  "spec_files": [
+    "**/*[sS]pec.js",
+    "**/*[sS]pec.jsx"
+  ]
+}

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,135 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - dist/**/*.js
+#
+src_files:
+  - javascripts/**/*.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - stylesheets/*.css
+#
+stylesheets:
+  - stylesheets/**/*.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - helpers/**/*.js
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - **/*[sS]pec.js
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir: src
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir: spec
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# random
+#
+# Run specs in semi-random order.
+# Default: false
+#
+# EXAMPLE:
+#
+# random: true
+#
+random:
+

--- a/src/javascripts/location-autocomplete.jsx
+++ b/src/javascripts/location-autocomplete.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+
+class LocationAutocomplete extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.geolocate = this.geolocate.bind(this);
+  }
+
+  componentDidMount() {
+    const autocompleteLibrary = document.getElementById("location-autocomplete-library");
+
+    if (autocompleteLibrary) {
+      if (this.constructor.libraryHasLoaded()) {
+        this.initAutocomplete();
+      } else {
+        autocompleteLibrary.addEventListener("load",  () => { this.initAutocomplete(); });
+      }
+    } else if (this.constructor.libraryHasLoaded()) {
+      this.initAutocomplete();
+    } else {
+      this.addAutocompleteLibrary();
+    }
+  }
+
+  static libraryHasLoaded() {
+    return typeof google !== "undefined";
+  }
+
+  addAutocompleteLibrary() {
+    const _this = this;
+    let scriptTag = document.createElement("script");
+    scriptTag.type = "text/javascript";
+    scriptTag.id = "location-autocomplete-library";
+    if (this.props.googleAPIKey) {
+      scriptTag.src = `https://maps.googleapis.com/maps/api/js?key=${this.props.googleAPIKey}&libraries=places&call`;
+    } else if (this.props.googlePlacesLibraryURL) {
+      scriptTag.src = this.props.googlePlacesLibraryURL;
+
+    }
+    (document.head || document.body).appendChild(scriptTag);
+
+    scriptTag.addEventListener("load", () => { _this.initAutocomplete(); });
+  }
+
+  initAutocomplete() {
+    // eslint-disable-next-line no-undef
+    this.autocomplete = new google.maps.places.Autocomplete(this.input, { types: [this.props.locationType] });
+    this.autocomplete.addListener("place_changed", this.props.handleDropdownSelect);
+  }
+
+  geolocate() {
+    if (this.constructor.libraryHasLoaded()) {
+      const _this = this;
+
+      if (this.props.targetArea) {
+        // eslint-disable-next-line no-undef
+        const geocoder = new google.maps.Geocoder();
+        geocoder.geocode({address: this.props.targetArea}, (results) => {
+          const place = results[0].geometry.location;
+
+          _this.setBounds(place);
+        });
+      } else if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition((position) => {
+          const geolocation = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
+          };
+
+          _this.setBounds(geolocation);
+        });
+      }
+    }
+  }
+
+  setBounds(position) {
+    // eslint-disable-next-line no-undef
+    const circle = new google.maps.Circle({
+      center: position,
+      radius: position.coords ? position.coords.accuracy : 100
+    });
+
+    this.autocomplete.setBounds(circle.getBounds());
+  }
+
+  render() {
+    return (
+      <input
+        type="text"
+        name={this.props.name}
+        id={this.props.id}
+        placeholder={this.props.placeholder}
+        classNames={`${this.props.classNames} location-field-autocomplete-component`}
+        ref={(input) => { this.input = input; }}
+        value={this.props.value}
+        onChange={this.props.onChange}
+        onFocus={this.geolocate}
+        style={this.props.style}
+      />
+    );
+  }
+}
+
+LocationAutocomplete.defaultProps = {
+  locationType: "geocode"
+};
+
+LocationAutocomplete.propTypes = {
+  name: React.PropTypes.string,
+  id: React.PropTypes.string,
+  placeholder: React.PropTypes.string,
+  classNames: React.PropTypes.string,
+  style: React.PropTypes.object,
+  value: React.PropTypes.string,
+  targetArea: React.PropTypes.string,
+  locationType: React.PropTypes.string,
+  onChange: React.PropTypes.func.isRequired,
+  handleDropdownSelect: React.PropTypes.func.isRequired,
+  googleAPIKey: React.PropTypes.string,
+  googlePlacesLibraryURL: React.PropTypes.string
+};
+
+export default LocationAutocomplete;

--- a/test-context.js
+++ b/test-context.js
@@ -1,0 +1,3 @@
+var context = require.context('./spec', true, /-spec\.js$/);
+
+context.keys().forEach(context);

--- a/test-context.js
+++ b/test-context.js
@@ -1,3 +1,3 @@
-var context = require.context('./spec', true, /-spec\.js$/);
+var context = require.context('./spec', true, /-spec\.js$|-spec\.jsx$/);
 
 context.keys().forEach(context);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  entry: "./src/javascripts/index.js",
+  entry: "./src/javascripts/location-autocomplete.jsx",
   output: {
     path: "./",
     filename: "bundle.js"
@@ -7,7 +7,7 @@ module.exports = {
   module: {
     loaders: [
       {
-        test: /\.js$/,
+        test: /\.js$|.jsx$/,
         exclude: /node_modules/,
         loader: "babel-loader",
         query:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  entry: "./src/javascripts/index.js",
+  output: {
+    path: "./",
+    filename: "bundle.js"
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: "babel-loader",
+        query:
+          {
+            presets: ["react"]
+          }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This commit introduces a tested location field component with autocomplete
functionality.  It leverages the Google Places API to provide a typeahead
effect.

Features:
- configurable to:
  - [x] bias suggestions by "target area" or by current location
  - [x] provide suggestions by location type
- allows multiple instances to be used on single page, without importing
autocomplete library multiple times

References:
- For a list of supported location type, visit https://developers.google.com/places/supported_types